### PR TITLE
fix links and explain how to join the google group

### DIFF
--- a/frescobaldi.org/links.html
+++ b/frescobaldi.org/links.html
@@ -31,7 +31,12 @@
 
 <h3>Frescobaldi</h3>
 <ul>
-<li><a href="http://groups.google.com/group/frescobaldi">Frescobaldi Mailinglist</a></li>
+<li><a href="http://groups.google.com/group/frescobaldi">Frescobaldi Mailinglist</a>
+&mdash; You don't need a Google account to subscribe to the mailing list.
+Just visit the <a href="https://groups.google.com/forum/#!forum/frescobaldi/join ">subscribe page</a> to join the group
+and the <a href="https://groups.google.com/forum/#!forum/frescobaldi/unsubscribe ">unsubscribe page</a>
+to quit the group. Messages should be sent to <em>frescobaldi@googlegroups.com</em>.
+</li>
 <li><a href="https://github.com/wbsoft/frescobaldi">Github project page for Frescobaldi 2.0</a>, download, issue tracker, etc</li>
 <li><a href="http://lilykde.googlecode.com/">GoogleCode project page for Frescobaldi 1.x</a></li>
 <li><a href="http://www.kde-apps.org/content/show.php/Frescobaldi?content=95853">Frescobaldi 1.x @ KDE-Apps.org</a></li>
@@ -47,11 +52,10 @@ Frescobaldi is already included in:
 </p>
 
 <ul>
-<li><a href="http://packages.debian.org/nl/squeeze/editors/frescobaldi">Debian (testing)</a></li>
-<li>Ubuntu:
-  <a href="http://packages.ubuntu.com/karmic/frescobaldi">Karmic (9.10)</a>,
-  <a href="http://packages.ubuntu.com/lucid/frescobaldi">Lucid (10.4)</a>
-</li>
+<li><a href="https://packages.debian.org/search?keywords=frescobaldi">Debian</a></li>
+<li><a href="http://packages.ubuntu.com/search?keywords=frescobaldi">Ubuntu</a></li>
+<li><a href="https://apps.fedoraproject.org/packages/frescobaldi">Fedora</a></li>
+<li><a href="https://software.opensuse.org/package/frescobaldi">OpenSUSE</a></li>
 <li><a href="http://packages.gentoo.org/package/media-sound/frescobaldi">Gentoo Linux</a></li>
 <li>Arch Linux: <a href="https://aur.archlinux.org/packages/frescobaldi/">Stable</a>, <a href="https://aur.archlinux.org/packages/frescobaldi-git/">Development</a></li>
 </ul>

--- a/frescobaldi.org/uguide-1/entering.html
+++ b/frescobaldi.org/uguide-1/entering.html
@@ -126,8 +126,8 @@ See the &quot;What's This&quot; info (Shift+F1) for more information.
 <h3><a name="rumor" id="rumor"></a>MIDI input via Rumor (Linux only)</h3>
 
 <div style="float: right; width: 326px;"><a
-href="/uguide/images/rumor1.png"><img border="0"
-src="/uguide/images/rumor1-small.png"
+href="/uguide-1/images/rumor1.png"><img border="0"
+src="/uguide-1/images/rumor1-small.png"
 width="326" height="373" alt="Rumor" title="Click to enlarge"/></a><br />
 <em>The Rumor tab and settings dialog</em></div>
 


### PR DESCRIPTION
As discussed here: https://groups.google.com/forum/#!topic/frescobaldi/6MlXeotcP_M

I think that putting the plain email address is fine. Google should have a strong spam filter. And probably spammers can already guess the email address from the group's public link.